### PR TITLE
feat: complete benchmarks frontend

### DIFF
--- a/backend/api/benchmarks/routes.py
+++ b/backend/api/benchmarks/routes.py
@@ -17,7 +17,7 @@ async def get_benchmarks(
     page_size: int = Query(50, ge=1, le=100, description="Number of items per page"),
     sort_by: str = Query("task_name", description="Field to sort by"),
     sort_order: str = Query("asc", pattern="^(asc|desc)$", description="Sort order"),
-    tag: str | None = Query(None, description="Filter by tag"),
+    tag: list[str] | None = Query(None, description="Filter by tag (supports multiple)"),
     author: str | None = Query(None, description="Filter by author"),
     search: str | None = Query(None, description="Search in task_name, dataset_name, or hf_repo"),
     session: AsyncSession = Depends(get_session),

--- a/backend/api/benchmarks/service.py
+++ b/backend/api/benchmarks/service.py
@@ -24,11 +24,15 @@ class BenchmarkService:
         page_size: int = 50,
         sort_by: str = "task_name",
         sort_order: str = "asc",
-        tag_filter: Optional[str] = None,
+        tag_filter: Optional[list[str]] = None,
         author_filter: Optional[str] = None,
         search_query: Optional[str] = None,
     ) -> BenchmarkListResponse:
         """Get all benchmarks with filtering, sorting, and pagination.
+        
+        Note: This service layer currently acts as a pass-through to the repository
+        with response formatting. It's maintained for future business logic additions
+        and to keep a consistent service layer pattern across the application.
 
         Args:
             page: Page number (1-indexed)

--- a/backend/scripts/benchmark_utils.py
+++ b/backend/scripts/benchmark_utils.py
@@ -1,0 +1,265 @@
+import re
+
+# Valid benchmark type tags from Lighteval
+VALID_BENCHMARK_TAGS = {
+    "bias", "biology", "biomedical", "chemistry", "classification", "code-generation",
+    "commonsense", "conversational", "dialog", "dialogue", "emotion", "ethics", "factuality",
+    "general-knowledge", "generation", "geography", "graduate-level", "health", "history",
+    "instruction-following", "justice", "knowledge", "language", "language-modeling",
+    "language-understanding", "legal", "long-context", "math", "medical", "morality",
+    "multi-turn", "multilingual", "multimodal", "multiple-choice", "narrative", "nli",
+    "physical-commonsense", "physics", "qa", "question-answering", "reading-comprehension",
+    "reasoning", "safety", "science", "scientific", "summarization", "symbolic", "translation",
+    "utilitarianism", "virtue", "coding", "information-retrieval", "retrieval",
+    "text-generation", "text-classification", "token-classification", "causal-lm",
+}
+
+# Keywords to infer tags from task/dataset names
+# Format: "keyword": ["tag1", "tag2"]
+INFERRED_TAG_KEYWORDS = {
+    "math": ["math", "reasoning"],
+    "gsm8k": ["math", "reasoning"],
+    "aime": ["math", "reasoning"],
+    "algebra": ["math", "reasoning"],
+    "arithmetic": ["math", "reasoning"],
+    "code": ["coding", "code-generation"],
+    "coding": ["coding", "code-generation"],
+    "humaneval": ["coding", "code-generation"],
+    "mbpp": ["coding", "code-generation"],
+    "mmlu": ["general-knowledge", "knowledge"],
+    "knowledge": ["knowledge"],
+    "common": ["commonsense"],
+    "qa": ["qa"],
+    "question": ["qa"],
+    "nli": ["nli"],
+    "chat": ["conversational"],
+    "dialog": ["dialogue"],
+    "summar": ["summarization"],
+    "translat": ["translation"],
+    "medic": ["medical"],
+    "bio": ["biology"],
+    "chem": ["chemistry"],
+    "physic": ["physics"],
+    "scien": ["science"],
+    "legal": ["legal"],
+    "histor": ["history"],
+    "geograph": ["geography"],
+    "logic": ["reasoning"],
+    "reason": ["reasoning"],
+    "emotion": ["emotion"],
+    "factiv": ["factuality"],
+    "truth": ["factuality"],
+}
+
+# Language code mappings (HuggingFace to ISO 639-1)
+# Maps various language codes and names to standardized two-letter codes
+LANGUAGE_CODE_MAP = {
+    # English
+    "en": "en", "eng": "en", "english": "en",
+    # Chinese
+    "zh": "zh", "zh-cn": "zh", "zh-hans": "zh", "zh-hant": "zh", 
+    "zh-tw": "zh", "chi": "zh", "chinese": "zh", "zho": "zh", "cmn": "zh",
+    # Arabic
+    "ar": "ar", "ara": "ar", "arabic": "ar", "arb": "ar",
+    # French
+    "fr": "fr", "fra": "fr", "fre": "fr", "french": "fr",
+    # Russian
+    "ru": "ru", "rus": "ru", "russian": "ru",
+    # Spanish
+    "es": "es", "spa": "es", "spanish": "es", "esp": "es",
+    # German
+    "de": "de", "deu": "de", "ger": "de", "german": "de",
+    # Hindi
+    "hi": "hi", "hin": "hi", "hindi": "hi",
+    # Additional common languages
+    "ja": "ja", "jpn": "ja", "japanese": "ja",
+    "ko": "ko", "kor": "ko", "korean": "ko",
+    "pt": "pt", "por": "pt", "portuguese": "pt", "pt-br": "pt",
+    "it": "it", "ita": "it", "italian": "it",
+    "nl": "nl", "nld": "nl", "dut": "nl", "dutch": "nl",
+    "pl": "pl", "pol": "pl", "polish": "pl",
+    "tr": "tr", "tur": "tr", "turkish": "tr",
+    "vi": "vi", "vie": "vi", "vietnamese": "vi",
+    "th": "th", "tha": "th", "thai": "th",
+    "id": "id", "ind": "id", "indonesian": "id",
+    "uk": "uk", "ukr": "uk", "ukrainian": "uk",
+    "he": "he", "heb": "he", "hebrew": "he",
+    "fa": "fa", "fas": "fa", "per": "fa", "persian": "fa",
+    "bn": "bn", "ben": "bn", "bengali": "bn",
+    "te": "te", "tel": "te", "telugu": "te",
+    "ta": "ta", "tam": "ta", "tamil": "ta",
+    "sw": "sw", "swa": "sw", "swahili": "sw",
+}
+
+def normalize_language_code(lang_code: str) -> str | None:
+    """
+    Normalize language code to standard two-letter ISO 639-1 format.
+    
+    Args:
+        lang_code: Language code from HuggingFace (can be en, eng, english, zh-CN, etc.)
+        
+    Returns:
+        Normalized two-letter language code or None if not recognized
+    """
+    if not lang_code:
+        return None
+    
+    # Convert to lowercase and strip whitespace
+    lang_code = lang_code.lower().strip()
+    
+    # Look up in mapping
+    return LANGUAGE_CODE_MAP.get(lang_code)
+
+def filter_benchmark_tags(tags: list[str]) -> list[str]:
+    """
+    Filter and normalize tags to include valid benchmark type tags and normalized language tags.
+    """
+    if not tags:
+        return []
+    
+    filtered = []
+    seen_languages = set()
+    seen_tags = set()
+    
+    # Process each tag
+    for tag in tags:
+        tag_lower = tag.lower()
+        
+        # Handle language tags - normalize and deduplicate
+        if tag_lower.startswith("language:"):
+            lang_code = tag_lower.split(":", 1)[1] if ":" in tag_lower else None
+            if lang_code:
+                normalized = normalize_language_code(lang_code)
+                if normalized and normalized not in seen_languages:
+                    filtered.append(f"language:{normalized}")
+                    seen_languages.add(normalized)
+            continue
+        
+        # Check if this is a plain language code/name that should be converted to language:XX
+        normalized_lang = normalize_language_code(tag_lower)
+        if normalized_lang and normalized_lang not in seen_languages:
+            # This is a language identifier, convert to standard format
+            filtered.append(f"language:{normalized_lang}")
+            seen_languages.add(normalized_lang)
+            continue
+            
+        # Skip tags with special prefixes that are metadata
+        if any(tag_lower.startswith(prefix) for prefix in [
+            "task_categories:", "task_ids:", "size_categories:", "license:",
+            "doi:", "region:", "source_datasets:", "format:",
+            "annotations_creators:", "language_creators:", "multilinguality:",
+            "pretty_name:", "config_name:", "data_files:", "dataset_info:",
+            "args:", "kwargs:", 
+        ]):
+            continue
+            
+        # Skip size indicators
+        if any(indicator in tag_lower for indicator in ["<n<", ">", "k", "m", "b"]) and any(
+            char.isdigit() for char in tag
+        ):
+            continue
+            
+        # Skip common metadata tags
+        if tag_lower in [
+            "text", "json", "csv", "parquet", "text-file", "jsonl",
+            "cc0-1.0", "mit", "apache-2.0", "cc-by-4.0", "cc-by-sa-4.0",
+            "other", "unknown", "monolingual", "multilingual", "crowdsourced",
+            "found", "automatic", "extended", "other-", "dataset", "datasets",
+            "transformers", "nlp", "llm", "large-language-model",
+            "audio", "image", "video", "multimodal",
+        ]:
+            continue
+
+        # Allow arxiv tags through directly
+        if tag_lower.startswith("arxiv:"):
+            if tag_lower not in seen_tags:
+                filtered.append(tag) 
+                seen_tags.add(tag_lower)
+            continue
+
+        # For remaining tags, try to match against valid benchmark tags
+        normalized_str = tag_lower.replace("-", " ").replace("_", " ")
+        parts = normalized_str.split()
+        
+        candidate = tag_lower
+        if candidate in VALID_BENCHMARK_TAGS:
+             if candidate not in seen_tags:
+                filtered.append(candidate)
+                seen_tags.add(candidate)
+        
+        candidate_hyphen = tag_lower.replace("_", "-")
+        if candidate_hyphen in VALID_BENCHMARK_TAGS:
+             if candidate_hyphen not in seen_tags:
+                filtered.append(candidate_hyphen)
+                seen_tags.add(candidate_hyphen)
+
+        for part in parts:
+            if part in VALID_BENCHMARK_TAGS:
+                if part not in seen_tags:
+                    filtered.append(part)
+                    seen_tags.add(part)
+    
+    return filtered
+
+def infer_tags_from_task_info(task_name: str, description: str | None = None) -> list[str]:
+    """
+    Infer tags based on keywords in the task/dataset name and description.
+    """
+    inferred = set()
+    name_lower = task_name.lower()
+    for keyword, tags in INFERRED_TAG_KEYWORDS.items():
+        if keyword in name_lower:
+            for tag in tags:
+                inferred.add(tag)
+    return list(inferred)
+
+def clean_description(description: str | None) -> str | None:
+    """
+    Clean and extract a readable summary from HuggingFace dataset description.
+    """
+    if not description:
+        return None
+    
+    # Remove "Dataset Card for X" headers
+    text = re.sub(r'^#*\s*Dataset Card for[^\n]*\n*', '', description, flags=re.IGNORECASE | re.MULTILINE)
+    
+    # Remove table of contents sections
+    text = re.sub(r'##?\s*Table of Contents.*?(?=##|\Z)', '', text, flags=re.IGNORECASE | re.DOTALL)
+    
+    # Remove all markdown headers but keep the content after them
+    text = re.sub(r'^#{1,6}\s+', '', text, flags=re.MULTILINE)
+    
+    # Remove markdown links but keep the text: [text](url) -> text
+    text = re.sub(r'\[([^\]]+)\]\([^\)]+\)', r'\1', text)
+    
+    # Remove markdown bold/italic
+    text = re.sub(r'\*\*([^\*]+)\*\*', r'\1', text)
+    text = re.sub(r'\*([^\*]+)\*', r'\1', text)
+    
+    # Remove horizontal rules
+    text = re.sub(r'^[-*_]{3,}\s*$', '', text, flags=re.MULTILINE)
+    
+    # Remove citation blocks (starting with >)
+    text = re.sub(r'^>\s+.*$', '', text, flags=re.MULTILINE)
+    
+    # Split into paragraphs and get first meaningful ones
+    paragraphs = [p.strip() for p in text.split('\n\n') if p.strip()]
+    
+    # Filter out paragraphs that are too short or look like section headers
+    meaningful_paragraphs = [
+        p for p in paragraphs 
+        if len(p) > 50 and not p.endswith(':') and len(p.split()) > 8
+    ]
+    
+    if not meaningful_paragraphs:
+        return '\n\n'.join(paragraphs[:2])[:500] if paragraphs else None
+    
+    result = '\n\n'.join(meaningful_paragraphs[:2])
+    
+    if len(result) > 500:
+        result = result[:500]
+        last_period = max(result.rfind('.'), result.rfind('!'), result.rfind('?'))
+        if last_period > 200:
+            result = result[:last_period + 1]
+    
+    return result.strip() if result.strip() else None

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import Results from "@/pages/results";
 import Datasets from "@/pages/datasets";
 import Guidelines from "@/pages/guidelines";
 import Profile from "@/pages/profile";
+import Benchmarks from "@/pages/benchmarks";
 
 function Router() {
   return (
@@ -22,6 +23,7 @@ function Router() {
       <Route path="/results" component={Results} />
       <Route path="/datasets" component={Datasets} />
       <Route path="/guidelines" component={Guidelines} />
+      <Route path="/benchmarks" component={Benchmarks} />
       <Route path="/profile" component={Profile} />
       {/* Fallback to 404 */}
       <Route component={NotFound} />

--- a/frontend/src/components/layout.tsx
+++ b/frontend/src/components/layout.tsx
@@ -23,6 +23,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 
   const navItems = [
     { label: "Leaderboard", href: "/" },
+    { label: "Benchmarks", href: "/benchmarks" },
     { label: "Datasets", href: "/datasets" },
     { label: "Guidelines", href: "/guidelines" },
     { label: "Compare Models", href: "/compare" },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -254,6 +254,75 @@ class ApiClient {
     }>(`/leaderboard?dataset_name=${encodeURIComponent(datasetName)}`);
   }
 
+  // Benchmark endpoints
+  async getBenchmarks(params?: {
+    page?: number;
+    page_size?: number;
+    sort_by?: string;
+    sort_order?: 'asc' | 'desc';
+    tags?: string[];
+    author?: string;
+    search?: string;
+  }) {
+    const queryParams = new URLSearchParams();
+    if (params?.page) queryParams.append('page', params.page.toString());
+    if (params?.page_size) queryParams.append('page_size', params.page_size.toString());
+    if (params?.sort_by) queryParams.append('sort_by', params.sort_by);
+    if (params?.sort_order) queryParams.append('sort_order', params.sort_order);
+    if (params?.tags) {
+        params.tags.forEach(tag => queryParams.append('tag', tag));
+    }
+    if (params?.author) queryParams.append('author', params.author);
+    if (params?.search) queryParams.append('search', params.search);
+
+    const query = queryParams.toString();
+    return this.request<{
+      benchmarks: {
+        id: number;
+        task_name: string;
+        dataset_name: string;
+        hf_repo: string;
+        description: string | null;
+        author: string | null;
+        downloads: number | null;
+        tags: string[] | null;
+        estimated_input_tokens: number | null;
+        repo_type: string | null;
+        created_at_hf: string | null;
+        private: boolean | null;
+        gated: boolean | null;
+        files: string[] | null;
+        created_at: string;
+        updated_at: string;
+      }[];
+      total: number;
+      page: number;
+      page_size: number;
+      total_pages: number;
+    }>(`/benchmarks${query ? '?' + query : ''}`);
+  }
+
+  async getBenchmark(benchmarkId: number) {
+    return this.request<{
+      id: number;
+      task_name: string;
+      dataset_name: string;
+      hf_repo: string;
+      description: string | null;
+      author: string | null;
+      downloads: number | null;
+      tags: string[] | null;
+      estimated_input_tokens: number | null;
+      repo_type: string | null;
+      created_at_hf: string | null;
+      private: boolean | null;
+      gated: boolean | null;
+      files: string[] | null;
+      created_at: string;
+      updated_at: string;
+    }>(`/benchmarks/${benchmarkId}`);
+  }
+
   // Health check
   async health() {
     return this.request<{ status: string }>('/health');

--- a/frontend/src/pages/benchmarks.tsx
+++ b/frontend/src/pages/benchmarks.tsx
@@ -1,0 +1,537 @@
+import Layout from "@/components/layout";
+import { Card, CardContent, CardHeader, CardTitle, CardFooter } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { ExternalLink, Search, ChevronLeft, ChevronRight, ChevronDown, ChevronUp, Download, Box } from "lucide-react";
+import { useState, useMemo, useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { apiClient } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+// Valid benchmark type tags from Lighteval (backend/scripts/benchmark_utils.py)
+const VALID_BENCHMARK_TAGS = [
+  "bias", "biology", "biomedical", "chemistry", "classification", "code-generation",
+  "commonsense", "conversational", "dialog", "dialogue", "emotion", "ethics", "factuality",
+  "general-knowledge", "generation", "geography", "graduate-level", "health", "history",
+  "instruction-following", "justice", "knowledge", "language", "language-modeling",
+  "language-understanding", "legal", "long-context", "math", "medical", "morality",
+  "multi-turn", "multilingual", "multimodal", "multiple-choice", "narrative", "nli",
+  "physical-commonsense", "physics", "qa", "question-answering", "reading-comprehension",
+  "reasoning", "safety", "science", "scientific", "summarization", "symbolic", "translation",
+  "utilitarianism", "virtue", "coding", "information-retrieval", "retrieval",
+  "text-generation", "text-classification", "token-classification", "causal-lm",
+].sort();
+
+// Language codes that map to language:XX tags with specific colors for filters
+const LANGUAGE_FILTERS = [
+  { code: "en", label: "english", color: "bg-blue-100 text-blue-800" },
+  { code: "zh", label: "chinese", color: "bg-red-100 text-red-800" },
+  { code: "ar", label: "arabic", color: "bg-green-100 text-green-800" },
+  { code: "fr", label: "french", color: "bg-purple-100 text-purple-800" },
+  { code: "ru", label: "russian", color: "bg-pink-100 text-pink-800" },
+  { code: "es", label: "spanish", color: "bg-yellow-100 text-yellow-800" },
+  { code: "de", label: "german", color: "bg-indigo-100 text-indigo-800" },
+  { code: "hi", label: "hindi", color: "bg-orange-100 text-orange-800" },
+  { code: "ja", label: "japanese", color: "bg-rose-100 text-rose-800" },
+  { code: "ko", label: "korean", color: "bg-cyan-100 text-cyan-800" },
+  { code: "pt", label: "portuguese", color: "bg-lime-100 text-lime-800" },
+  { code: "it", label: "italian", color: "bg-teal-100 text-teal-800" },
+  { code: "nl", label: "dutch", color: "bg-amber-100 text-amber-800" },
+  { code: "pl", label: "polish", color: "bg-fuchsia-100 text-fuchsia-800" },
+  { code: "tr", label: "turkish", color: "bg-emerald-100 text-emerald-800" },
+  { code: "vi", label: "vietnamese", color: "bg-sky-100 text-sky-800" },
+  { code: "th", label: "thai", color: "bg-violet-100 text-violet-800" },
+  { code: "id", label: "indonesian", color: "bg-stone-100 text-stone-800" },
+  { code: "uk", label: "ukrainian", color: "bg-blue-100 text-blue-800" },
+  { code: "he", label: "hebrew", color: "bg-indigo-100 text-indigo-800" },
+  { code: "fa", label: "persian", color: "bg-purple-100 text-purple-800" },
+  { code: "bn", label: "bengali", color: "bg-green-100 text-green-800" },
+  { code: "te", label: "telugu", color: "bg-orange-100 text-orange-800" },
+  { code: "ta", label: "tamil", color: "bg-red-100 text-red-800" },
+  { code: "sw", label: "swahili", color: "bg-teal-100 text-teal-800" },
+];
+
+export default function Benchmarks() {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [selectedLanguages, setSelectedLanguages] = useState<string[]>([]);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [showAllLanguages, setShowAllLanguages] = useState(false);
+  const [showAllTags, setShowAllTags] = useState(false);
+  const [expandedDescriptions, setExpandedDescriptions] = useState<Set<number>>(new Set());
+  const [expandedTagLists, setExpandedTagLists] = useState<Set<number>>(new Set());
+  
+  // Adjusted to 100 to meet backend limit (ge=1, le=100)
+  const FETCH_PAGE_SIZE = 100;
+  const ITEMS_PER_PAGE = 12;
+
+
+  // Fetch benchmarks
+  const { data, isLoading } = useQuery({
+    queryKey: ['benchmarks', searchQuery, selectedLanguages, selectedTags], // Refetch when filters change
+    queryFn: () => {
+      // Convert selected languages to language:XX format and combine with selected tags
+      const languageTags = selectedLanguages.map(code => `language:${code}`);
+      const allTags = [...languageTags, ...selectedTags];
+      
+      return apiClient.getBenchmarks({
+        page: 1,
+        page_size: FETCH_PAGE_SIZE,
+        search: searchQuery || undefined,
+        tags: allTags.length > 0 ? allTags : undefined,
+      });
+    },
+  });
+
+  const allBenchmarks = data?.benchmarks || [];
+
+  // Get all tags separated by type, excluding arxiv tags which are handled separately
+  const getAllTagsForDisplay = (tags: string[] | null) => {
+    if (!tags) return { benchmarkTags: [], languageTags: [], arxivId: null };
+    
+    const benchmarkTags: string[] = [];
+    const languageTags: string[] = [];
+    let arxivId: string | null = null;
+    
+    tags.forEach(tag => {
+      if (tag.startsWith('language:')) {
+        // Extract just the language name for display
+        const langCode = tag.split(':')[1];
+        const langFilter = LANGUAGE_FILTERS.find(l => l.code === langCode);
+        if (langFilter) {
+          languageTags.push(langFilter.label);
+        } else {
+            languageTags.push(langCode);
+        }
+      } else if (tag.startsWith('arxiv:')) {
+          arxivId = tag.replace('arxiv:', '');
+      } else {
+        benchmarkTags.push(tag);
+      }
+    });
+    
+    return { benchmarkTags, languageTags, arxivId };
+  };
+  
+  // Unified tag style for all tags in the card
+  const TAG_STYLE = "bg-yellow-100 text-yellow-800 hover:bg-yellow-200 border-transparent";
+
+  // Client-side Pagination
+  const totalItems = useMemo(() => allBenchmarks.length, [allBenchmarks]);
+  const totalPages = useMemo(
+    () => Math.max(1, Math.ceil(totalItems / ITEMS_PER_PAGE)),
+    [totalItems]
+  );
+  
+  const currentBenchmarks = useMemo(() => {
+    const start = (currentPage - 1) * ITEMS_PER_PAGE;
+    return allBenchmarks.slice(start, start + ITEMS_PER_PAGE);
+  }, [allBenchmarks, currentPage]);
+
+  // Reset page when filters change
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [selectedLanguages, selectedTags, searchQuery]);
+
+  // Generic toggle function for string arrays
+  const createToggle = (setter: React.Dispatch<React.SetStateAction<string[]>>) => 
+    (value: string) => {
+      setter(prev =>
+        prev.includes(value)
+          ? prev.filter(v => v !== value)
+          : [...prev, value]
+      );
+    };
+
+  const toggleLanguage = createToggle(setSelectedLanguages);
+  const toggleTag = createToggle(setSelectedTags);
+
+  // Generic toggle function for Set<number>
+  const createSetToggle = (setter: React.Dispatch<React.SetStateAction<Set<number>>>) =>
+    (id: number) => {
+      setter(prev => {
+        const newSet = new Set(prev);
+        if (newSet.has(id)) {
+          newSet.delete(id);
+        } else {
+          newSet.add(id);
+        }
+        return newSet;
+      });
+    };
+
+  const toggleDescriptionExpansion = createSetToggle(setExpandedDescriptions);
+  const toggleTagListExpansion = createSetToggle(setExpandedTagLists);
+
+  const handleSearch = (value: string) => {
+    setSearchQuery(value);
+  };
+
+  // Description is already cleaned by the backend, just use it directly
+  const getDescription = (benchmark: any) => {
+    return benchmark.description || benchmark.dataset_name || "No description available";
+  };
+
+  // Get visible language filters
+  // Show first 8 languages always, plus any that are currently selected or available in data
+  const displayedLanguageFilters = LANGUAGE_FILTERS;
+  const visibleLanguages = showAllLanguages 
+    ? displayedLanguageFilters 
+    : displayedLanguageFilters.slice(0, 8);
+
+  // Show all valid benchmark tags
+  const displayedTags = showAllTags ? VALID_BENCHMARK_TAGS : VALID_BENCHMARK_TAGS.slice(0, 15);
+
+  return (
+    <Layout>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className="text-4xl font-bold font-display mb-2">
+            <span className="text-mint-600">Lighteval</span> Tasks Explorer
+          </h1>
+          <p className="text-muted-foreground">
+            Browse tasks by language, tags and search the task descriptions.
+          </p>
+          <p className="text-sm text-muted-foreground mt-1">
+            {totalItems} tasks
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
+          {/* Sidebar Filters */}
+          <div className="lg:col-span-1 space-y-6">
+            {/* Search */}
+            <Card>
+              <CardHeader className="pb-3">
+                <CardTitle className="text-base font-medium">Search</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="relative">
+                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+                  <Input
+                    placeholder="Search in module path, tags, abstract..."
+                    value={searchQuery}
+                    onChange={(e) => handleSearch(e.target.value)}
+                    className="text-sm pl-9"
+                  />
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Languages */}
+            {displayedLanguageFilters.length > 0 && (
+              <Card>
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-base font-medium">Languages</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="grid grid-cols-2 gap-2">
+                      {visibleLanguages.map((lang) => (
+                        <div key={lang.code} className="flex items-center space-x-2">
+                          <Checkbox
+                            id={`lang-${lang.code}`}
+                            checked={selectedLanguages.includes(lang.code)}
+                            onCheckedChange={() => toggleLanguage(lang.code)}
+                          />
+                          <Label
+                            htmlFor={`lang-${lang.code}`}
+                            className="text-xs font-normal leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer capitalize"
+                          >
+                              <Badge variant="secondary" className={cn("font-normal border-transparent", lang.color)}>
+                                {lang.label}
+                              </Badge>
+                          </Label>
+                        </div>
+                      ))}
+                    </div>
+                     {displayedLanguageFilters.length > 8 && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setShowAllLanguages(!showAllLanguages)}
+                        className="w-full text-xs mt-2"
+                      >
+                        {showAllLanguages ? "Show less" : "Show all languages"}
+                      </Button>
+                    )}
+                </CardContent>
+              </Card>
+            )}
+
+            {/* Benchmark Type / Tags */}
+            <Card>
+              <CardHeader className="pb-3">
+                <CardTitle className="text-base font-medium">Benchmark type</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-2 gap-2">
+                  {displayedTags.map((tag) => (
+                    <div key={tag} className="flex items-start space-x-2">
+                      <Checkbox
+                        id={`tag-${tag}`}
+                        checked={selectedTags.includes(tag)}
+                        onCheckedChange={() => toggleTag(tag)}
+                        className="mt-0.5"
+                      />
+                      <Label
+                        htmlFor={`tag-${tag}`}
+                        className="text-sm font-normal leading-tight peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer break-words"
+                      >
+                        {tag}
+                      </Label>
+                    </div>
+                  ))}
+                </div>
+                 {VALID_BENCHMARK_TAGS.length > 15 && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setShowAllTags(!showAllTags)}
+                      className="w-full text-xs mt-2"
+                    >
+                      {showAllTags ? "Show less" : `Show ${VALID_BENCHMARK_TAGS.length - 15} more`}
+                    </Button>
+                  )}
+              </CardContent>
+            </Card>
+            
+            <div className="text-xs text-muted-foreground">
+              Tip: use the filters and search together. Results update live.
+            </div>
+          </div>
+
+          {/* Main Content - Benchmark Cards */}
+          <div className="lg:col-span-3">
+            {isLoading ? (
+              <div className="text-center py-12">
+                <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-solid border-current border-r-transparent align-[-0.125em] motion-reduce:animate-[spin_1.5s_linear_infinite]" />
+                <p className="mt-4 text-muted-foreground">Loading benchmarks...</p>
+              </div>
+            ) : allBenchmarks.length === 0 ? (
+              <Card>
+                <CardContent className="pt-12 pb-12 text-center">
+                  <p className="text-muted-foreground">
+                    No benchmarks found matching your filters.
+                  </p>
+                </CardContent>
+              </Card>
+            ) : (
+              <>
+                {/* Benchmark Cards Grid */}
+                <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 mb-6">
+                  {currentBenchmarks.map((benchmark) => {
+                    const isDescriptionExpanded = expandedDescriptions.has(benchmark.id);
+                    const isTagListExpanded = expandedTagLists.has(benchmark.id);
+                    const description = getDescription(benchmark);
+                    const hasLongDescription = description && description.length > 150;
+                    const { benchmarkTags, languageTags, arxivId } = getAllTagsForDisplay(benchmark.tags);
+                    
+                    return (
+                      <Card key={benchmark.id} className="hover:shadow-md transition-shadow flex flex-col overflow-hidden h-full">
+                        <CardHeader className="pb-3 break-words space-y-3">
+                          <div className="flex items-start justify-between gap-2">
+                            <CardTitle className="text-lg font-bold flex items-center gap-2 break-words overflow-hidden leading-tight">
+                              <span className="break-words">{benchmark.task_name}</span>
+                            </CardTitle>
+                          </div>
+                          
+                          {/* Tags */}
+                          {(() => {
+                            const allDisplayTags = [...benchmarkTags, ...languageTags];
+                            const hasDisplayTags = allDisplayTags.length > 0;
+                            
+                            if (!hasDisplayTags) return null;
+                            
+                            const visibleCount = 5; 
+                            const showExpandedTags = isTagListExpanded;
+                            const visibleBenchmarkTags = showExpandedTags ? benchmarkTags : benchmarkTags.slice(0, Math.min(visibleCount - languageTags.length, benchmarkTags.length));
+                            const visibleLanguageTags = showExpandedTags ? languageTags : languageTags;
+                            const hasMoreTags = benchmarkTags.length + languageTags.length > visibleCount;
+                            
+                            return (
+                              <div className="flex flex-wrap gap-1.5 align-top">
+                                {/* Benchmark type tags */}
+                                {visibleBenchmarkTags.map((tag, idx) => (
+                                  <Badge
+                                    key={`bench-${idx}`}
+                                    variant="secondary"
+                                    className={cn(
+                                      "px-2.5 py-0.5 text-xs font-normal border-0",
+                                      TAG_STYLE
+                                    )}
+                                  >
+                                    {tag}
+                                  </Badge>
+                                ))}
+                                
+                                {/* Language tags */}
+                                {visibleLanguageTags.map((tag, idx) => (
+                                  <Badge
+                                    key={`lang-${idx}`}
+                                    variant="secondary" 
+                                    className={cn(
+                                      "px-2.5 py-0.5 text-xs font-normal border-0",
+                                      TAG_STYLE
+                                    )}
+                                  >
+                                    {tag}
+                                  </Badge>
+                                ))}
+                                
+                                {hasMoreTags && !showExpandedTags && (
+                                  <button
+                                    onClick={() => toggleTagListExpansion(benchmark.id)}
+                                    className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-normal bg-gray-100 text-gray-700 hover:bg-gray-200 cursor-pointer"
+                                  >
+                                    +{allDisplayTags.length - visibleCount} more
+                                  </button>
+                                )}
+                                
+                                {showExpandedTags && (
+                                  <button
+                                    onClick={() => toggleTagListExpansion(benchmark.id)}
+                                    className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-normal bg-gray-100 text-gray-700 hover:bg-gray-200 cursor-pointer"
+                                  >
+                                    <ChevronUp className="w-3 h-3 mr-1" />
+                                    Show less
+                                  </button>
+                                )}
+                              </div>
+                            );
+                          })()}
+                        </CardHeader>
+                        
+                        <CardContent className="flex-1 flex flex-col pt-0">
+                          <div className={cn(
+                            "text-sm text-muted-foreground mb-4 break-words overflow-hidden",
+                            !isDescriptionExpanded && "line-clamp-4"
+                          )}>
+                             {description}
+                          </div>
+                          
+                          {hasLongDescription && (
+                            <div className="mb-4">
+                                <Button
+                                variant="ghost"
+                                className="h-auto p-0 text-xs text-muted-foreground hover:text-foreground cursor-pointer"
+                                onClick={() => toggleDescriptionExpansion(benchmark.id)}
+                                >
+                                {isDescriptionExpanded ? (
+                                    <>
+                                        <ChevronUp className="w-3 h-3 mr-1" />
+                                        Show less
+                                    </>
+                                ) : (
+                                    <>
+                                        <ChevronDown className="w-3 h-3 mr-1" />
+                                        Show more
+                                    </>
+                                )}
+                                </Button>
+                            </div>
+                          )}
+                        
+                          <div className="mt-auto space-y-4">
+                            {/* Metrics */}
+                            {(benchmark.downloads !== null || benchmark.estimated_input_tokens !== null) && (
+                                <div className="flex items-center gap-4 text-xs text-muted-foreground">
+                                    {benchmark.downloads !== null && (
+                                        <div className="flex items-center gap-1" title="Downloads">
+                                            <Download className="w-3 h-3" />
+                                            <span>{benchmark.downloads.toLocaleString()}</span>
+                                        </div>
+                                    )}
+                                    {benchmark.estimated_input_tokens !== null && (
+                                        <div className="flex items-center gap-1" title="Estimated Input Tokens">
+                                            <Box className="w-3 h-3" />
+                                            <span>{benchmark.estimated_input_tokens.toLocaleString()} tokens</span>
+                                        </div>
+                                    )}
+                                </div>
+                            )}
+
+                            {/* Run using Lighteval button */}
+                            <div className="pt-2 border-t">
+                                <p className="text-[10px] text-muted-foreground uppercase font-semibold mb-2">RUN USING LIGHTEVAL:</p>
+                                <div className="bg-mint-50 rounded-md p-2 border border-mint-100 w-fit max-w-[90%]">
+                                    <code className="text-xs text-mint-700 font-mono break-all block">
+                                        {benchmark.task_name}
+                                    </code>
+                                </div>
+                            </div>
+                        </div>
+                        </CardContent>
+                        
+                        <CardFooter className="pt-3 pb-4 text-xs text-blue-600 gap-3 border-t bg-muted/5">
+                            <a 
+                                href={benchmark.hf_repo.startsWith('http') ? benchmark.hf_repo : `https://huggingface.co/datasets/${benchmark.hf_repo}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="flex items-center gap-1 hover:underline font-medium"
+                            >
+                                source
+                                <ExternalLink className="w-3 h-3 flex-shrink-0" />
+                            </a>
+                            
+                            {arxivId && (
+                                <>
+                                    <span className="text-muted-foreground">|</span>
+                                    <a 
+                                        href={`https://arxiv.org/abs/${arxivId}`}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="flex items-center gap-1 hover:underline font-medium"
+                                    >
+                                        paper
+                                        <ExternalLink className="w-3 h-3 flex-shrink-0" />
+                                    </a>
+                                </>
+                            )}
+                        </CardFooter>
+                      </Card>
+                    );
+                  })}
+                </div>
+
+                {/* Pagination */}
+                {totalPages > 1 && (
+                  <div className="flex justify-center mt-8">
+                      <div className="flex items-center gap-2">
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
+                            disabled={currentPage === 1}
+                            className="cursor-pointer"
+                        >
+                            <ChevronLeft className="w-4 h-4 mr-1" />
+                            Previous
+                        </Button>
+                        <span className="text-sm font-medium mx-2">
+                            Page {currentPage} of {totalPages}
+                        </span>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
+                            disabled={currentPage === totalPages}
+                            className="cursor-pointer"
+                        >
+                            Next
+                            <ChevronRight className="w-4 h-4 ml-1" />
+                        </Button>
+                      </div>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+}


### PR DESCRIPTION
- fixed tags on benchmarks db and descriptions
- added benchmarks page (frontend)

**Note**:
- tasks that have separate subtasks are currently completely different data entities, e.g. `gpqa:diamond` and `gpqa:extended` are separate tasks/datasets right now though they're part of the same parent one `gpqa`.