### PR TITLE
feat: Add task details view for benchmarks

### DIFF
--- a/backend/api/benchmarks/routes.py
+++ b/backend/api/benchmarks/routes.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.benchmarks.schemas import BenchmarkListResponse, BenchmarkResponse
+from api.benchmarks.schemas import BenchmarkListResponse, BenchmarkResponse, TaskDetailsResponse
 from api.benchmarks.service import BenchmarkService
 from api.core.database import get_session
 from api.core.logging import get_logger
@@ -52,3 +52,13 @@ async def get_benchmark(
     """Get a single benchmark by ID."""
     logger.debug(f"Getting benchmark: {benchmark_id}")
     return await BenchmarkService(session).get_benchmark(benchmark_id)
+
+
+@router.get("/task-details/{task_name}", response_model=TaskDetailsResponse)
+async def get_task_details(
+    task_name: str,
+    session: AsyncSession = Depends(get_session),
+) -> TaskDetailsResponse:
+    """Get task details by task name."""
+    logger.debug(f"Getting task details: {task_name}")
+    return await BenchmarkService(session).get_task_details(task_name)

--- a/backend/api/benchmarks/schemas.py
+++ b/backend/api/benchmarks/schemas.py
@@ -35,3 +35,9 @@ class BenchmarkListResponse(BaseModel):
     page: int
     page_size: int
     total_pages: int
+
+class TaskDetailsResponse(BaseModel):
+    """Response schema for task details."""
+
+    task_name: str
+    task_details_nested_dict: Optional[dict] = None

--- a/backend/api/benchmarks/service.py
+++ b/backend/api/benchmarks/service.py
@@ -3,9 +3,8 @@ from typing import Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.benchmarks.models import Benchmark
 from api.benchmarks.repository import BenchmarkRepository
-from api.benchmarks.schemas import BenchmarkListResponse, BenchmarkResponse
+from api.benchmarks.schemas import BenchmarkListResponse, BenchmarkResponse, TaskDetailsResponse
 from api.core.logging import get_logger
 
 logger = get_logger(__name__)
@@ -91,3 +90,18 @@ class BenchmarkService:
         if benchmark:
             return BenchmarkResponse.model_validate(benchmark)
         return None
+
+    async def get_task_details(self, task_name: str) -> TaskDetailsResponse:
+        """Get task details by task name.
+
+        Args:
+            task_name: Task name
+
+        Returns:
+            TaskDetailsResponse: Found task details
+        """
+        response = TaskDetailsResponse(task_name=task_name)
+        task_details_nested_dict = await self.repository.get_task_details(task_name)
+        if task_details_nested_dict:
+            response.task_details_nested_dict = task_details_nested_dict
+        return response

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -326,6 +326,14 @@ class ApiClient {
     }>(`/benchmarks/${benchmarkId}`);
   }
 
+  async getTaskDetails(taskName: string) {
+    const response = await this.request<{
+      task_name: string;
+      task_details_nested_dict: Record<string, any> | null;
+    }>(`/benchmarks/task-details/${encodeURIComponent(taskName)}`);
+    return response.task_details_nested_dict || {};
+  }
+
   // Health check
   async health() {
     return this.request<{ status: string }>('/health');


### PR DESCRIPTION
## Summary
This PR adds the ability to view detailed task configuration information for benchmarks in the UI.

## Changes

### Backend
- Added `TaskDetailsResponse` schema for task details API response
- Implemented `get_task_details` endpoint at `/benchmarks/task-details/{task_name}`
- Added repository method to fetch task details from lighteval registry
- Added helper method to convert task config objects to serializable dictionaries

### Frontend
- Added `getTaskDetails` API client method
- Implemented expandable task details UI in benchmarks page
- Added recursive `NestedValue` component to display nested task configuration
- Task details are loaded on-demand when user expands a task

## Features
- Users can now click on any task in a benchmark to see its detailed configuration
- Nested objects and arrays are displayed in a collapsible tree view
- Task details are fetched lazily only when expanded
- Loading states and error handling included

## Testing
- Tested with various benchmark tasks to ensure proper rendering of nested configurations