### PR TITLE
add visual guide when creating evaluation

### DIFF
--- a/backend/api/benchmarks/routes.py
+++ b/backend/api/benchmarks/routes.py
@@ -3,6 +3,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.benchmarks.schemas import (
     BenchmarkListResponse,
+    BenchmarkPreviewResponse,
     BenchmarkResponse,
     BenchmarkTasksListResponse,
     TaskDetailsResponse,
@@ -81,3 +82,18 @@ async def get_benchmark_tasks(
     """Get all tasks for a benchmark with size and token information."""
     logger.debug(f"Getting tasks for benchmark: {benchmark_id}")
     return await BenchmarkService(session).get_benchmark_tasks(benchmark_id)
+
+
+@router.get("/{benchmark_id}/preview", response_model=BenchmarkPreviewResponse)
+async def get_benchmark_preview(
+    benchmark_id: int,
+    num_samples: int = Query(10, ge=1, le=50, description="Number of samples to return"),
+    session: AsyncSession = Depends(get_session),
+) -> BenchmarkPreviewResponse:
+    """Get a preview of benchmark data from HuggingFace.
+
+    Streams data from HuggingFace to avoid downloading the entire dataset.
+    Returns the first `num_samples` rows from the dataset.
+    """
+    logger.debug(f"Getting preview for benchmark: {benchmark_id}")
+    return await BenchmarkService(session).get_benchmark_preview(benchmark_id, num_samples)

--- a/backend/api/benchmarks/schemas.py
+++ b/backend/api/benchmarks/schemas.py
@@ -66,3 +66,11 @@ class BenchmarkTasksListResponse(BaseModel):
     """Response schema for listing benchmark tasks."""
 
     tasks: list[BenchmarkTaskResponse]
+
+
+class BenchmarkPreviewResponse(BaseModel):
+    """Response schema for benchmark data preview."""
+
+    samples: list[dict]
+    hf_repo: str
+    dataset_name: str

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -471,6 +471,14 @@ class ApiClient {
     return response.task_details_nested_dict || {};
   }
 
+  async getBenchmarkPreview(benchmarkId: number, numSamples: number = 10) {
+    return this.request<{
+      samples: any[];
+      hf_repo: string;
+      dataset_name: string;
+    }>(`/benchmarks/${benchmarkId}/preview?num_samples=${numSamples}`);
+  }
+
   // Models and Providers endpoints
   async getProviders(params?: { page?: number; page_size?: number }) {
     const queryParams = new URLSearchParams();


### PR DESCRIPTION
show preview of custom dataset
<img width="1768" height="864" alt="image" src="https://github.com/user-attachments/assets/dfa114b8-c9cf-4746-9526-0a0e2a0e3357" />

There is also a 'show example' field for most options which allows the user to expand it to see an example of what the field is used for
<img width="1816" height="1182" alt="image" src="https://github.com/user-attachments/assets/41d1a817-e4cf-418d-a9a0-cdcb69e0626c" />
