### PR TITLE
gfeat: add download endpoint for evaluation traces/results

### DIFF
--- a/backend/api/core/s3.py
+++ b/backend/api/core/s3.py
@@ -337,3 +337,33 @@ class S3Storage:
         except ClientError as e:
             logger.error(f"Failed to download file from S3: {e}")
             raise
+
+    def get_file_stream(self, key: str):
+        """Get a streaming body for a file in S3.
+
+        Returns:
+            The StreamingBody from boto3's get_object response.
+
+        Raises:
+            FileNotFoundError: If the key doesn't exist.
+        """
+        try:
+            response = self.client.get_object(Bucket=self.bucket, Key=key)
+            return response["Body"]
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "NoSuchKey":
+                raise FileNotFoundError(f"File not found in S3: {key}")
+            logger.error(f"Failed to get file stream from S3: {e}")
+            raise
+
+    def eval_results_exist(self, trace_id: int) -> bool:
+        """Check if evaluation results exist in S3 for a given trace."""
+        prefix = f"{EVAL_RESULTS_PREFIX}/{trace_id}/"
+        try:
+            response = self.client.list_objects_v2(
+                Bucket=self.bucket, Prefix=prefix, MaxKeys=1
+            )
+            return response.get("KeyCount", 0) > 0
+        except ClientError as e:
+            logger.error(f"Failed to check eval results existence: {e}")
+            return False

--- a/backend/api/evaluations/routes.py
+++ b/backend/api/evaluations/routes.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, status
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
 
@@ -153,3 +153,39 @@ async def get_trace_progress(
     if progress is None:
         return JSONResponse(content=None)
     return progress
+
+
+@router.get("/traces/{trace_id}/download")
+async def download_trace_results(
+    trace_id: int,
+    session: AsyncSession = Depends(get_session),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> StreamingResponse:
+    """Download evaluation results as a zip archive."""
+    import io
+    import os
+    import zipfile
+
+    from api.core.s3 import S3Storage
+
+    service = EvaluationService(session, current_user.id)
+    files, prefix = await service.get_trace_download_files(trace_id)
+
+    s3 = S3Storage()
+
+    def generate_zip():
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            for s3_key in files:
+                relative_path = os.path.relpath(s3_key, prefix)
+                body = s3.get_file_stream(s3_key)
+                zf.writestr(relative_path, body.read())
+        buf.seek(0)
+        yield buf.read()
+
+    filename = f"eval_results_{trace_id}.zip"
+    return StreamingResponse(
+        generate_zip(),
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/backend/api/evaluations/service.py
+++ b/backend/api/evaluations/service.py
@@ -1,9 +1,9 @@
 from fastapi import HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.core.exceptions import NotFoundException
+from api.core.exceptions import BadRequestException, NotFoundException
 from api.core.logging import get_logger
-from api.core.s3 import S3Storage
+from api.core.s3 import EVAL_RESULTS_PREFIX, S3Storage
 from api.evaluations.models import Trace
 from api.evaluations.repository import EvaluationRepository
 from api.evaluations.schemas import (
@@ -394,6 +394,29 @@ class EvaluationService:
             judge_model_provider=trace.judge_model_provider,
             spec=spec_event.data,
         )
+
+    async def get_trace_download_files(self, trace_id: int) -> tuple[list[str], str]:
+        """Get the list of S3 keys for a trace's eval results, after validating access.
+
+        Returns:
+            Tuple of (list of S3 keys, S3 prefix).
+
+        Raises:
+            HTTPException 403: If user doesn't own the trace.
+            BadRequestException: If trace is not completed.
+            NotFoundException: If no result files exist.
+        """
+        trace = await self.get_trace(trace_id)
+
+        if trace.status != "completed":
+            raise BadRequestException("Evaluation results are only available for completed runs")
+
+        prefix = f"{EVAL_RESULTS_PREFIX}/{trace_id}"
+        files = self.s3.list_files(prefix)
+        if not files:
+            raise NotFoundException("No evaluation result files found for this trace")
+
+        return files, prefix
 
     async def get_trace_samples(
         self, request: TraceSamplesRequest

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -370,6 +370,27 @@ class ApiClient {
     return this.request<{ samples: Record<string, unknown>[] }>(`/evaluations/traces/${traceId}/samples`);
   }
 
+  async downloadTraceResults(traceId: number) {
+    const headers: Record<string, string> = {};
+    if (this.token) {
+      headers['Authorization'] = `Bearer ${this.token}`;
+    }
+    const response = await fetch(`${API_BASE}/evaluations/traces/${traceId}/download`, { headers });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ detail: 'Download failed' }));
+      throw new Error(typeof error.detail === 'string' ? error.detail : 'Download failed');
+    }
+    const blob = await response.blob();
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `eval_results_${traceId}.zip`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    window.URL.revokeObjectURL(url);
+  }
+
   async getEvalProgress(traceId: number) {
     return this.request<{ stage: string; percent: number | null; detail: string } | null>(
       `/evaluations/traces/${traceId}/progress`

--- a/frontend/src/pages/results.tsx
+++ b/frontend/src/pages/results.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Progress } from "@/components/ui/progress";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { RefreshCw, Clock, CheckCircle, XCircle, Loader2, Eye, Info, AlertTriangle, ChevronLeft, ChevronRight } from "lucide-react";
+import { RefreshCw, Clock, CheckCircle, XCircle, Loader2, Eye, Info, AlertTriangle, ChevronLeft, ChevronRight, Download } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { apiClient } from "@/lib/api";
 import { useAuth } from "@/hooks/use-auth";
@@ -90,6 +90,19 @@ export default function Results() {
   });
 
   const traceSamples = traceSamplesData?.samples || [];
+
+  const [downloadingTraceId, setDownloadingTraceId] = useState<number | null>(null);
+
+  const handleDownload = async (traceId: number) => {
+    setDownloadingTraceId(traceId);
+    try {
+      await apiClient.downloadTraceResults(traceId);
+    } catch (err) {
+      console.error('Download failed:', err);
+    } finally {
+      setDownloadingTraceId(null);
+    }
+  };
 
   const getStatusBadge = (status: string) => {
     switch (status) {
@@ -422,6 +435,7 @@ export default function Results() {
                       </TableCell>
                       <TableCell>
                         {trace.status === "completed" && trace.summary && (
+                          <div className="flex items-center gap-1">
                           <Dialog>
                             <DialogTrigger asChild>
                               <Button
@@ -626,6 +640,21 @@ export default function Results() {
                               )}
                             </DialogContent>
                           </Dialog>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="gap-2"
+                            onClick={() => handleDownload(trace.id)}
+                            disabled={downloadingTraceId === trace.id}
+                          >
+                            {downloadingTraceId === trace.id ? (
+                              <Loader2 className="w-4 h-4 animate-spin" />
+                            ) : (
+                              <Download className="w-4 h-4" />
+                            )}
+                            Download
+                          </Button>
+                          </div>
                         )}
                         {trace.status === "failed" && trace.summary?.error && (
                           <Dialog>


### PR DESCRIPTION
Allow users to download the full lighteval output directory as a zip archive after an evaluation completes. Access is restricted to the trace owner via existing auth checks.