### PR TITLE
Centralized trace logging

### DIFF
--- a/backend/api/core/logging.py
+++ b/backend/api/core/logging.py
@@ -1,20 +1,36 @@
+import json
 import logging
 import sys
 
 from api.core.config import settings
+from api.core.trace_context import trace_id_var
+
+
+class JSONFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        return json.dumps({
+            "timestamp": self.formatTime(record),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "trace_id": trace_id_var.get(""),
+            "module": record.module,
+            "func": record.funcName,
+        })
 
 
 def setup_logging() -> None:
-    """Set up logging configuration."""
-    format_string = "[%(asctime)s] [%(levelname)s] [%(name)s] %(message)s"
-    logging.basicConfig(
-        level=logging.DEBUG if settings.DEBUG else logging.INFO,
-        format=format_string,
-        datefmt="%H:%M:%S",
-        stream=sys.stdout,
-    )
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG if settings.DEBUG else logging.INFO)
+
+    if not any(isinstance(h.formatter, JSONFormatter) for h in root.handlers):
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(JSONFormatter())
+        root.addHandler(handler)
+
+    for name in ("uvicorn", "uvicorn.access", "uvicorn.error", "celery", "celery.worker"):
+        logging.getLogger(name).setLevel(logging.WARNING)
 
 
 def get_logger(name: str) -> logging.Logger:
-    """Get a logger instance."""
     return logging.getLogger(name)

--- a/backend/api/core/trace_context.py
+++ b/backend/api/core/trace_context.py
@@ -1,0 +1,19 @@
+import contextvars
+import uuid
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+trace_id_var: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "trace_id", default=""
+)
+
+
+class TraceIDMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next) -> Response:
+        tid = request.headers.get("x-trace-id") or str(uuid.uuid4())
+        trace_id_var.set(tid)
+        response = await call_next(request)
+        response.headers["x-trace-id"] = tid
+        return response

--- a/backend/api/core/trace_context.py
+++ b/backend/api/core/trace_context.py
@@ -13,7 +13,10 @@ trace_id_var: contextvars.ContextVar[str] = contextvars.ContextVar(
 class TraceIDMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next) -> Response:
         tid = request.headers.get("x-trace-id") or str(uuid.uuid4())
-        trace_id_var.set(tid)
-        response = await call_next(request)
-        response.headers["x-trace-id"] = tid
-        return response
+        token = trace_id_var.set(tid)
+        try:
+            response = await call_next(request)
+            response.headers["x-trace-id"] = tid
+            return response
+        finally:
+            trace_id_var.reset(token)

--- a/backend/api/evaluations/service.py
+++ b/backend/api/evaluations/service.py
@@ -3,6 +3,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.core.exceptions import BadRequestException, NotFoundException
 from api.core.logging import get_logger
+from api.core.trace_context import trace_id_var
 from api.core.s3 import EVAL_RESULTS_PREFIX, S3Storage
 from api.evaluations.models import Trace
 from api.evaluations.repository import EvaluationRepository
@@ -74,6 +75,7 @@ class EvaluationService:
             n_fewshots=request.dataset_config.n_fewshots,
             model_config_data=model_config_data,
             request_data=request_data,
+            request_trace_id=trace_id_var.get(""),
         )
 
         # Return immediately with running status
@@ -158,6 +160,7 @@ class EvaluationService:
             model_config_data=model_config_data,
             judge_config_data=judge_config_data,
             request_data=request_data,
+            request_trace_id=trace_id_var.get(""),
         )
 
         # Return immediately with running status

--- a/backend/api/evaluations/tasks.py
+++ b/backend/api/evaluations/tasks.py
@@ -5,6 +5,7 @@ import json
 import statistics
 import tempfile
 import traceback
+import uuid
 from dataclasses import asdict
 from pathlib import Path
 
@@ -19,6 +20,7 @@ from lighteval.tasks.registry import Registry
 
 from api.core.celery_app import celery_app
 from api.core.logging import get_logger
+from api.core.trace_context import trace_id_var
 from api.core.redis_client import clear_eval_progress, set_eval_progress
 from api.evaluations.eval_pipeline.eval_pipeline import (
     CustomTaskEvaluationPipeline,
@@ -576,8 +578,10 @@ def run_task_evaluation_task(
     n_fewshots: int | None,
     model_config_data: dict,
     request_data: dict,
+    request_trace_id: str = "",
 ) -> None:
     """Celery task: run a task evaluation pipeline, post-process results, handle errors."""
+    trace_id_var.set(request_trace_id or str(uuid.uuid4()))
     try:
         logger.info(f"Starting task evaluation for trace {trace_id}")
         set_eval_progress(trace_id, "starting", 0, "Initializing...")
@@ -670,8 +674,10 @@ def run_flexible_evaluation_task(
     model_config_data: dict,
     judge_config_data: dict | None,
     request_data: dict,
+    request_trace_id: str = "",
 ) -> None:
     """Celery task: run a flexible evaluation pipeline, post-process results, handle errors."""
+    trace_id_var.set(request_trace_id or str(uuid.uuid4()))
     try:
         logger.info(f"Starting flexible evaluation for trace {trace_id}")
         set_eval_progress(trace_id, "starting", 0, "Initializing...")

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -10,6 +10,7 @@ from api.benchmarks.routes import router as benchmarks_router
 from api.core.config import settings
 from api.core.logging import get_logger, setup_logging
 from api.core.ratelimiter import limiter
+from api.core.trace_context import TraceIDMiddleware
 from api.core.redis_client import close_async_redis_client
 from api.datasets.routes import router as datasets_router
 from api.evaluation_comparison.routes import router as evaluation_comparison_router
@@ -47,6 +48,7 @@ app = FastAPI(
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 app.add_middleware(SlowAPIASGIMiddleware)
+app.add_middleware(TraceIDMiddleware)
 
 # Create API router with /api prefix
 api_router = APIRouter(prefix="/api")

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -10,8 +10,8 @@ from api.benchmarks.routes import router as benchmarks_router
 from api.core.config import settings
 from api.core.logging import get_logger, setup_logging
 from api.core.ratelimiter import limiter
-from api.core.trace_context import TraceIDMiddleware
 from api.core.redis_client import close_async_redis_client
+from api.core.trace_context import TraceIDMiddleware
 from api.datasets.routes import router as datasets_router
 from api.evaluation_comparison.routes import router as evaluation_comparison_router
 from api.evaluations.routes import router as evaluations_router

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,3 +1,5 @@
+import uuid
+
 from fastapi.testclient import TestClient
 
 from api.main import app
@@ -18,3 +20,15 @@ def test_root_endpoint():
     assert response.status_code == 200
     assert "message" in response.json()
     assert "Evalhub" in response.json()["message"]
+
+
+def test_response_contains_trace_id_header():
+    response = client.get("/api/health")
+    trace_id = response.headers.get("x-trace-id")
+    assert trace_id is not None
+    uuid.UUID(trace_id)
+
+
+def test_request_trace_id_is_echoed_back():
+    response = client.get("/api/health", headers={"x-trace-id": "custom-trace-abc"})
+    assert response.headers.get("x-trace-id") == "custom-trace-abc"

--- a/backend/tests/unit/test_logging.py
+++ b/backend/tests/unit/test_logging.py
@@ -1,0 +1,75 @@
+import json
+import logging
+
+from api.core.logging import JSONFormatter, get_logger, setup_logging
+from api.core.trace_context import trace_id_var
+
+
+class TestJSONFormatter:
+    def test_output_is_valid_json(self):
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="hello", args=(), exc_info=None,
+        )
+        output = formatter.format(record)
+        parsed = json.loads(output)
+        assert parsed["message"] == "hello"
+        assert parsed["level"] == "INFO"
+        assert parsed["logger"] == "test"
+
+    def test_includes_trace_id_from_context(self):
+        formatter = JSONFormatter()
+        token = trace_id_var.set("test-trace-123")
+        try:
+            record = logging.LogRecord(
+                name="test", level=logging.INFO, pathname="", lineno=0,
+                msg="with trace", args=(), exc_info=None,
+            )
+            output = formatter.format(record)
+            parsed = json.loads(output)
+            assert parsed["trace_id"] == "test-trace-123"
+        finally:
+            trace_id_var.reset(token)
+
+    def test_trace_id_empty_when_no_context(self):
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="no trace", args=(), exc_info=None,
+        )
+        output = formatter.format(record)
+        parsed = json.loads(output)
+        assert parsed["trace_id"] == ""
+
+    def test_has_all_required_fields(self):
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            name="api.core.test", level=logging.WARNING, pathname="test.py",
+            lineno=42, msg="check fields", args=(), exc_info=None,
+        )
+        record.module = "test"
+        record.funcName = "test_func"
+        output = formatter.format(record)
+        parsed = json.loads(output)
+        assert set(parsed.keys()) == {
+            "timestamp", "level", "logger", "message",
+            "trace_id", "module", "func",
+        }
+
+
+class TestGetLogger:
+    def test_returns_named_logger(self):
+        log = get_logger("my.module")
+        assert log.name == "my.module"
+
+
+class TestSetupLogging:
+    def test_root_logger_has_json_formatter(self):
+        setup_logging()
+        root = logging.getLogger()
+        has_json = any(
+            isinstance(h.formatter, JSONFormatter)
+            for h in root.handlers
+        )
+        assert has_json

--- a/backend/tests/unit/test_logging.py
+++ b/backend/tests/unit/test_logging.py
@@ -65,6 +65,13 @@ class TestGetLogger:
 
 
 class TestSetupLogging:
+    def teardown_method(self):
+        root = logging.getLogger()
+        root.handlers = [
+            h for h in root.handlers
+            if not isinstance(h.formatter, JSONFormatter)
+        ]
+
     def test_root_logger_has_json_formatter(self):
         setup_logging()
         root = logging.getLogger()

--- a/backend/tests/unit/test_logging.py
+++ b/backend/tests/unit/test_logging.py
@@ -73,3 +73,15 @@ class TestSetupLogging:
             for h in root.handlers
         )
         assert has_json
+
+    def test_setup_logging_is_idempotent(self):
+        setup_logging()
+        root = logging.getLogger()
+        count_before = sum(
+            1 for h in root.handlers if isinstance(h.formatter, JSONFormatter)
+        )
+        setup_logging()
+        count_after = sum(
+            1 for h in root.handlers if isinstance(h.formatter, JSONFormatter)
+        )
+        assert count_before == count_after

--- a/backend/tests/unit/test_trace_context.py
+++ b/backend/tests/unit/test_trace_context.py
@@ -1,0 +1,49 @@
+import uuid
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.core.trace_context import TraceIDMiddleware, trace_id_var
+
+
+def _make_app():
+    app = FastAPI()
+    app.add_middleware(TraceIDMiddleware)
+
+    @app.get("/test")
+    async def test_endpoint():
+        return {"trace_id": trace_id_var.get("")}
+
+    return app
+
+
+class TestTraceIDVar:
+    def test_default_is_empty_string(self):
+        assert trace_id_var.get("") == ""
+
+    def test_set_and_get(self):
+        token = trace_id_var.set("abc-123")
+        assert trace_id_var.get("") == "abc-123"
+        trace_id_var.reset(token)
+
+
+class TestTraceIDMiddleware:
+    def test_generates_trace_id_when_no_header(self):
+        client = TestClient(_make_app())
+        response = client.get("/test")
+        assert response.status_code == 200
+        trace_id = response.headers.get("x-trace-id")
+        assert trace_id is not None
+        uuid.UUID(trace_id)
+
+    def test_uses_provided_trace_id_header(self):
+        client = TestClient(_make_app())
+        response = client.get("/test", headers={"x-trace-id": "my-custom-id"})
+        assert response.headers.get("x-trace-id") == "my-custom-id"
+        assert response.json()["trace_id"] == "my-custom-id"
+
+    def test_trace_id_available_in_endpoint(self):
+        client = TestClient(_make_app())
+        response = client.get("/test")
+        body = response.json()
+        assert body["trace_id"] == response.headers["x-trace-id"]

--- a/docs/superpowers/plans/2026-04-17-centralized-trace-logging.md
+++ b/docs/superpowers/plans/2026-04-17-centralized-trace-logging.md
@@ -1,0 +1,526 @@
+# Centralized Trace Logging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add request-scoped trace IDs and structured JSON logging to correlate logs across FastAPI requests and Celery worker tasks.
+
+**Architecture:** A `contextvars.ContextVar` holds a per-request trace ID set by FastAPI middleware. A custom `JSONFormatter` reads the context var and emits structured JSON on every log call. Celery tasks receive the trace ID as an explicit parameter and set the context var before doing work.
+
+**Tech Stack:** Python stdlib only (`contextvars`, `logging`, `json`, `uuid`). No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-04-17-centralized-trace-logging-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `backend/api/core/trace_context.py` | **New.** `ContextVar` for trace ID + `TraceIDMiddleware` |
+| `backend/api/core/logging.py` | **Modify.** Replace plain-text formatter with `JSONFormatter` that reads trace ID from context var |
+| `backend/api/main.py` | **Modify.** Register `TraceIDMiddleware` |
+| `backend/api/evaluations/service.py` | **Modify.** Pass `request_trace_id` when dispatching Celery tasks |
+| `backend/api/evaluations/tasks.py` | **Modify.** Accept `request_trace_id` param, set context var at task start |
+| `backend/tests/unit/test_trace_context.py` | **New.** Unit tests for trace context module |
+| `backend/tests/unit/test_logging.py` | **New.** Unit tests for JSON formatter |
+| `backend/tests/test_main.py` | **Modify.** Add test for trace ID in response headers |
+
+---
+
+### Task 1: Trace Context Module — ContextVar + Middleware
+
+**Files:**
+- Create: `backend/api/core/trace_context.py`
+- Test: `backend/tests/unit/test_trace_context.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/unit/test_trace_context.py`:
+
+```python
+import uuid
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.core.trace_context import TraceIDMiddleware, trace_id_var
+
+
+def _make_app():
+    app = FastAPI()
+    app.add_middleware(TraceIDMiddleware)
+
+    @app.get("/test")
+    async def test_endpoint():
+        return {"trace_id": trace_id_var.get("")}
+
+    return app
+
+
+class TestTraceIDVar:
+    def test_default_is_empty_string(self):
+        assert trace_id_var.get("") == ""
+
+    def test_set_and_get(self):
+        token = trace_id_var.set("abc-123")
+        assert trace_id_var.get("") == "abc-123"
+        trace_id_var.reset(token)
+
+
+class TestTraceIDMiddleware:
+    def test_generates_trace_id_when_no_header(self):
+        client = TestClient(_make_app())
+        response = client.get("/test")
+        assert response.status_code == 200
+        trace_id = response.headers.get("x-trace-id")
+        assert trace_id is not None
+        uuid.UUID(trace_id)
+
+    def test_uses_provided_trace_id_header(self):
+        client = TestClient(_make_app())
+        response = client.get("/test", headers={"x-trace-id": "my-custom-id"})
+        assert response.headers.get("x-trace-id") == "my-custom-id"
+        assert response.json()["trace_id"] == "my-custom-id"
+
+    def test_trace_id_available_in_endpoint(self):
+        client = TestClient(_make_app())
+        response = client.get("/test")
+        body = response.json()
+        assert body["trace_id"] == response.headers["x-trace-id"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/unit/test_trace_context.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'api.core.trace_context'`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `backend/api/core/trace_context.py`:
+
+```python
+import contextvars
+import uuid
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+trace_id_var: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "trace_id", default=""
+)
+
+
+class TraceIDMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next) -> Response:
+        tid = request.headers.get("x-trace-id") or str(uuid.uuid4())
+        trace_id_var.set(tid)
+        response = await call_next(request)
+        response.headers["x-trace-id"] = tid
+        return response
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/unit/test_trace_context.py -v`
+Expected: All 5 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd backend
+git add api/core/trace_context.py tests/unit/test_trace_context.py
+git commit -m "feat: add trace ID context var and middleware"
+```
+
+---
+
+### Task 2: Structured JSON Logging
+
+**Files:**
+- Modify: `backend/api/core/logging.py` (lines 1-21)
+- Test: `backend/tests/unit/test_logging.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/unit/test_logging.py`:
+
+```python
+import json
+import logging
+
+from api.core.logging import JSONFormatter, get_logger, setup_logging
+from api.core.trace_context import trace_id_var
+
+
+class TestJSONFormatter:
+    def test_output_is_valid_json(self):
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="hello", args=(), exc_info=None,
+        )
+        output = formatter.format(record)
+        parsed = json.loads(output)
+        assert parsed["message"] == "hello"
+        assert parsed["level"] == "INFO"
+        assert parsed["logger"] == "test"
+
+    def test_includes_trace_id_from_context(self):
+        formatter = JSONFormatter()
+        token = trace_id_var.set("test-trace-123")
+        try:
+            record = logging.LogRecord(
+                name="test", level=logging.INFO, pathname="", lineno=0,
+                msg="with trace", args=(), exc_info=None,
+            )
+            output = formatter.format(record)
+            parsed = json.loads(output)
+            assert parsed["trace_id"] == "test-trace-123"
+        finally:
+            trace_id_var.reset(token)
+
+    def test_trace_id_empty_when_no_context(self):
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="no trace", args=(), exc_info=None,
+        )
+        output = formatter.format(record)
+        parsed = json.loads(output)
+        assert parsed["trace_id"] == ""
+
+    def test_has_all_required_fields(self):
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            name="api.core.test", level=logging.WARNING, pathname="test.py",
+            lineno=42, msg="check fields", args=(), exc_info=None,
+        )
+        record.module = "test"
+        record.funcName = "test_func"
+        output = formatter.format(record)
+        parsed = json.loads(output)
+        assert set(parsed.keys()) == {
+            "timestamp", "level", "logger", "message",
+            "trace_id", "module", "func",
+        }
+
+
+class TestGetLogger:
+    def test_returns_named_logger(self):
+        log = get_logger("my.module")
+        assert log.name == "my.module"
+
+
+class TestSetupLogging:
+    def test_root_logger_has_json_formatter(self):
+        setup_logging()
+        root = logging.getLogger()
+        has_json = any(
+            isinstance(h.formatter, JSONFormatter)
+            for h in root.handlers
+        )
+        assert has_json
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/unit/test_logging.py -v`
+Expected: FAIL with `ImportError: cannot import name 'JSONFormatter' from 'api.core.logging'`
+
+- [ ] **Step 3: Write the implementation**
+
+Replace the contents of `backend/api/core/logging.py` with:
+
+```python
+import json
+import logging
+import sys
+
+from api.core.config import settings
+from api.core.trace_context import trace_id_var
+
+
+class JSONFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        return json.dumps({
+            "timestamp": self.formatTime(record),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "trace_id": trace_id_var.get(""),
+            "module": record.module,
+            "func": record.funcName,
+        })
+
+
+def setup_logging() -> None:
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG if settings.DEBUG else logging.INFO)
+
+    if not any(isinstance(h.formatter, JSONFormatter) for h in root.handlers):
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(JSONFormatter())
+        root.addHandler(handler)
+
+    for name in ("uvicorn", "uvicorn.access", "uvicorn.error", "celery", "celery.worker"):
+        logging.getLogger(name).setLevel(logging.WARNING)
+
+
+def get_logger(name: str) -> logging.Logger:
+    return logging.getLogger(name)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/unit/test_logging.py -v`
+Expected: All 6 tests PASS
+
+- [ ] **Step 5: Run existing tests to check for regressions**
+
+Run: `cd backend && python -m pytest tests/test_main.py -v`
+Expected: PASS (existing health check and root endpoint tests still work)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd backend
+git add api/core/logging.py tests/unit/test_logging.py
+git commit -m "feat: replace plain-text logging with JSON formatter and trace ID injection"
+```
+
+---
+
+### Task 3: Register Middleware in FastAPI App
+
+**Files:**
+- Modify: `backend/api/main.py` (lines 1-49)
+- Modify: `backend/tests/test_main.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `backend/tests/test_main.py`:
+
+```python
+import uuid
+
+
+def test_response_contains_trace_id_header():
+    response = client.get("/api/health")
+    trace_id = response.headers.get("x-trace-id")
+    assert trace_id is not None
+    uuid.UUID(trace_id)
+
+
+def test_request_trace_id_is_echoed_back():
+    response = client.get("/api/health", headers={"x-trace-id": "custom-trace-abc"})
+    assert response.headers.get("x-trace-id") == "custom-trace-abc"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/test_main.py::test_response_contains_trace_id_header tests/test_main.py::test_request_trace_id_is_echoed_back -v`
+Expected: FAIL (no `x-trace-id` header in response yet)
+
+- [ ] **Step 3: Register the middleware**
+
+In `backend/api/main.py`, add the import at the top (after the existing imports from `api.core`):
+
+```python
+from api.core.trace_context import TraceIDMiddleware
+```
+
+Then add the middleware registration right after the existing `app.add_middleware(SlowAPIASGIMiddleware)` line (line 49):
+
+```python
+app.add_middleware(TraceIDMiddleware)
+```
+
+The full middleware section should read:
+
+```python
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+app.add_middleware(SlowAPIASGIMiddleware)
+app.add_middleware(TraceIDMiddleware)
+```
+
+Note: Starlette processes middleware in reverse order of `add_middleware` calls. `TraceIDMiddleware` is added last so it runs **first** (outermost), ensuring the trace ID is available before rate limiting runs.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/test_main.py -v`
+Expected: All 4 tests PASS (2 existing + 2 new)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd backend
+git add api/main.py tests/test_main.py
+git commit -m "feat: register TraceIDMiddleware in FastAPI app"
+```
+
+---
+
+### Task 4: Celery Trace ID Propagation
+
+**Files:**
+- Modify: `backend/api/evaluations/service.py` (lines 68-77, 146-161)
+- Modify: `backend/api/evaluations/tasks.py` (lines 570-579, 658-673)
+
+This task modifies Celery task signatures and dispatch calls. No unit test is practical here since these tasks require database, Redis, S3, and LLM provider connections. Verification is done by inspecting the code changes and running existing tests for regressions.
+
+- [ ] **Step 1: Add trace ID propagation to `service.py`**
+
+In `backend/api/evaluations/service.py`, add the import at the top (after the existing `from api.core.logging import get_logger` line):
+
+```python
+from api.core.trace_context import trace_id_var
+```
+
+Then modify the `run_task_evaluation_task.delay()` call (lines 69-77) to pass `request_trace_id`:
+
+```python
+        run_task_evaluation_task.delay(
+            trace_id=trace.id,
+            user_id=self.user_id,
+            task_name=task_name,
+            n_samples=request.dataset_config.n_samples,
+            n_fewshots=request.dataset_config.n_fewshots,
+            model_config_data=model_config_data,
+            request_data=request_data,
+            request_trace_id=trace_id_var.get(""),
+        )
+```
+
+And modify the `run_flexible_evaluation_task.delay()` call (lines 147-161) to pass `request_trace_id`:
+
+```python
+        run_flexible_evaluation_task.delay(
+            trace_id=trace.id,
+            user_id=self.user_id,
+            dataset_name=request.dataset_name,
+            dataset_content=dataset_content,
+            input_field=request.input_field,
+            output_type=request.output_type.value,
+            judge_type=request.judge_type.value,
+            text_config=text_config_data,
+            mc_config=mc_config_data,
+            guidelines_data=guidelines_data,
+            model_config_data=model_config_data,
+            judge_config_data=judge_config_data,
+            request_data=request_data,
+            request_trace_id=trace_id_var.get(""),
+        )
+```
+
+- [ ] **Step 2: Add trace ID acceptance to `tasks.py`**
+
+In `backend/api/evaluations/tasks.py`, add two imports. Add `uuid` to the stdlib imports at the top of the file (after `import traceback` on line 7):
+
+```python
+import uuid
+```
+
+And add the trace context import after the existing `from api.core.logging import get_logger` line:
+
+```python
+from api.core.trace_context import trace_id_var
+```
+
+Then modify `run_task_evaluation_task` (lines 570-579) to accept and set the trace ID:
+
+```python
+def run_task_evaluation_task(
+    self,
+    trace_id: int,
+    user_id: str,
+    task_name: str,
+    n_samples: int | None,
+    n_fewshots: int | None,
+    model_config_data: dict,
+    request_data: dict,
+    request_trace_id: str = "",
+) -> None:
+    """Celery task: run a task evaluation pipeline, post-process results, handle errors."""
+    trace_id_var.set(request_trace_id or str(uuid.uuid4()))
+    try:
+```
+
+And modify `run_flexible_evaluation_task` (lines 658-673) similarly:
+
+```python
+def run_flexible_evaluation_task(
+    self,
+    trace_id: int,
+    user_id: str,
+    dataset_name: str,
+    dataset_content: str,
+    input_field: str,
+    output_type: str,
+    judge_type: str,
+    text_config: dict | None,
+    mc_config: dict | None,
+    guidelines_data: list[dict],
+    model_config_data: dict,
+    judge_config_data: dict | None,
+    request_data: dict,
+    request_trace_id: str = "",
+) -> None:
+    """Celery task: run a flexible evaluation pipeline, post-process results, handle errors."""
+    trace_id_var.set(request_trace_id or str(uuid.uuid4()))
+    try:
+```
+
+- [ ] **Step 3: Run existing tests for regressions**
+
+Run: `cd backend && python -m pytest tests/test_main.py tests/unit/ -v`
+Expected: All tests PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd backend
+git add api/evaluations/service.py api/evaluations/tasks.py
+git commit -m "feat: propagate trace ID from API requests to Celery tasks"
+```
+
+---
+
+### Task 5: Smoke Test — End-to-End Verification
+
+This is a manual verification step, not an automated test. It confirms that the full chain works with the running app.
+
+- [ ] **Step 1: Start the backend**
+
+Run: `cd backend && python -m api`
+
+- [ ] **Step 2: Make a request and verify JSON logs with trace ID**
+
+In another terminal:
+```bash
+curl -s http://localhost:8001/api/health -v 2>&1 | grep -i x-trace-id
+```
+
+Expected: Response includes `x-trace-id: <some-uuid>` header.
+
+Check the backend terminal output — logs should be JSON lines like:
+```json
+{"timestamp": "...", "level": "INFO", "logger": "api.main", "message": "Starting Evalhub application", "trace_id": "", "module": "main", "func": "lifespan"}
+```
+
+- [ ] **Step 3: Verify custom trace ID is echoed**
+
+```bash
+curl -s http://localhost:8001/api/health -H "x-trace-id: test-123" -v 2>&1 | grep -i x-trace-id
+```
+
+Expected: `x-trace-id: test-123`
+
+- [ ] **Step 4: Commit final state (if any adjustments were needed)**
+
+Only if changes were made during smoke testing:
+```bash
+git add -u
+git commit -m "fix: adjustments from smoke testing"
+```

--- a/docs/superpowers/specs/2026-04-17-centralized-trace-logging-design.md
+++ b/docs/superpowers/specs/2026-04-17-centralized-trace-logging-design.md
@@ -52,6 +52,7 @@ Request → TraceIDMiddleware → ContextVar → JSONFormatter → stdout (JSON)
 - `trace_id` is read from `trace_id_var.get("")` — zero changes to existing log call sites. Every `logger.info(...)` throughout the codebase automatically includes the trace ID.
 - `get_logger()` function signature unchanged — callers are unaffected.
 - `setup_logging()` configures a `StreamHandler` with the `JSONFormatter` on the root logger.
+- Noisy third-party loggers (e.g., `uvicorn.access`, `celery`) are suppressed to WARNING level to keep logs focused on application events.
 
 ### Layer 3: Celery Trace Propagation
 

--- a/docs/superpowers/specs/2026-04-17-centralized-trace-logging-design.md
+++ b/docs/superpowers/specs/2026-04-17-centralized-trace-logging-design.md
@@ -1,0 +1,90 @@
+# Centralized Trace Logging Design
+
+## Problem
+
+When a request hits the API, triggers a Celery task, and that task calls external services (LLM providers, S3, DB), there is no way to correlate logs across those boundaries. All logging is plain-text to stdout with no request IDs or structured format.
+
+## Scope
+
+- Backend only (no frontend changes)
+- No new dependencies (pure stdlib)
+- No infrastructure changes (Docker compose, AWS unchanged)
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Trace ID field name | `trace_id` | Context makes meaning clear vs. the evaluation `Trace` model |
+| Log format | Always JSON | Consistent everywhere; use `jq` locally |
+| Frontend propagation | Deferred | Keep scope tight; middleware generates IDs for all requests |
+| CloudWatch log shipping for Celery | Deferred | Separate concern; requires IAM policy review |
+| Middleware approach | `BaseHTTPMiddleware` | Simplest; body-buffering limitation irrelevant for JSON API responses |
+
+## Architecture
+
+Three layers, five files (one new, four modified):
+
+```
+Request → TraceIDMiddleware → ContextVar → JSONFormatter → stdout (JSON)
+                                  ↓
+                          Celery .delay(request_trace_id=...)
+                                  ↓
+                          Task sets ContextVar → JSONFormatter → stdout (JSON)
+```
+
+### Layer 1: Trace Context Module
+
+**New file: `backend/api/core/trace_context.py`**
+
+- A `contextvars.ContextVar[str]` named `trace_id_var` holds the current request's trace ID. This is async-safe and works across `await` boundaries.
+- A `TraceIDMiddleware` (Starlette `BaseHTTPMiddleware`) runs on every request:
+  1. Reads `X-Trace-ID` header if present, otherwise generates a `uuid4`
+  2. Sets `trace_id_var` so all downstream code can read it
+  3. Adds `X-Trace-ID` to the response headers
+- Registered in `main.py` alongside the existing SlowAPI middleware.
+
+### Layer 2: Structured JSON Logging
+
+**Modified file: `backend/api/core/logging.py`**
+
+- Replace the `logging.basicConfig` plain-text formatter with a `JSONFormatter` subclass of `logging.Formatter`.
+- Each log entry is a single JSON line with fields: `timestamp`, `level`, `logger`, `message`, `trace_id`, `module`, `func`.
+- `trace_id` is read from `trace_id_var.get("")` — zero changes to existing log call sites. Every `logger.info(...)` throughout the codebase automatically includes the trace ID.
+- `get_logger()` function signature unchanged — callers are unaffected.
+- `setup_logging()` configures a `StreamHandler` with the `JSONFormatter` on the root logger.
+
+### Layer 3: Celery Trace Propagation
+
+**Modified files: `backend/api/evaluations/service.py` and `backend/api/evaluations/tasks.py`**
+
+- **Service layer** (`service.py`): When dispatching via `.delay()`, read the current trace ID from `trace_id_var` and pass it as `request_trace_id` kwarg.
+- **Task functions** (`tasks.py`): Both `run_task_evaluation_task` and `run_flexible_evaluation_task` accept a new `request_trace_id: str = ""` parameter. First action in each task: `trace_id_var.set(request_trace_id or str(uuid.uuid4()))`. If triggered without a trace ID (e.g., manual Celery invocation), a new one is generated.
+- All `logger.*()` calls within tasks automatically include the trace ID via the JSONFormatter.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `backend/api/core/trace_context.py` | **New** — `ContextVar` + `TraceIDMiddleware` |
+| `backend/api/core/logging.py` | Replace formatter with `JSONFormatter` + trace ID injection |
+| `backend/api/main.py` | Register `TraceIDMiddleware` |
+| `backend/api/evaluations/service.py` | Pass `request_trace_id` when dispatching Celery tasks |
+| `backend/api/evaluations/tasks.py` | Accept + set `request_trace_id` param in both tasks |
+
+## Log Output Example
+
+```json
+{"timestamp": "2026-04-17 14:30:01", "level": "INFO", "logger": "api.evaluations.service", "message": "Starting task evaluation", "trace_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890", "module": "service", "func": "create_task_evaluation"}
+```
+
+## What This Enables
+
+- Search all logs for a single request: `grep "a1b2c3d4" logs.json` or CloudWatch Logs Insights `filter trace_id = "a1b2c3d4-..."`
+- Correlate API request logs with the Celery worker logs that processed the evaluation
+- Structured JSON format enables programmatic log parsing and future integration with log aggregation tools
+
+## Future Extensions (Not In Scope)
+
+- Frontend `X-Trace-ID` propagation from React `ApiClient`
+- Switch Celery Docker log driver to `awslogs` for unified CloudWatch querying
+- OpenTelemetry integration (trace ID foundation makes migration straightforward)


### PR DESCRIPTION
Add logging. It looks liek this:
```
{"timestamp": "2026-04-17 02:51:13,138", "level": "INFO", "logger": "api.main", "message": "Starting Evalhub application", "trace_id": "", "module": "main", "func": "lifespan"}
{"timestamp": "2026-04-17 02:51:23,164", "level": "INFO", "logger": "api.auth.service", "message": "User authenticated: admin@evalhub.com", "trace_id": "3d288c32-a65e-4d3c-bdfa-8d8c33d5f953", "module": "service", "func": "login"}
WARNING:  StatReload detected changes in 'api/__main__.py'. Reloading...
{"timestamp": "2026-04-17 02:52:05,849", "level": "INFO", "logger": "api.main", "message": "Shutting down Evalhub application", "trace_id": "", "module": "main", "func": "lifespan"}
WARNING:  StatReload detected changes in 'api/__main__.py'. Reloading...
{"timestamp": "2026-04-17 02:52:14,393", "level": "INFO", "logger": "api.main", "message": "Starting Evalhub application", "trace_id": "", "module": "main", "func": "lifespan"}
{"timestamp": "2026-04-17 02:52:22,116", "level": "INFO", "logger": "api.main", "message": "Starting Evalhub application", "trace_id": "", "module": "main", "func": "lifespan"}
WARNING:  StatReload detected changes in 'api/core/redis_client.py'. Reloading...
{"timestamp": "2026-04-17 02:53:07,054", "level": "INFO", "logger": "api.main", "message": "Shutting down Evalhub application", "trace_id": "", "module": "main", "func": "lifespan"}```